### PR TITLE
ユーザー登録画面の実装

### DIFF
--- a/src/public/index.php
+++ b/src/public/index.php
@@ -1,2 +1,49 @@
-<?php
-echo 'Welcome TECH QUEST!';
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Todoアプリ</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+        }
+        header {
+            background-color: #f8f9fa;
+            padding: 1rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 1px solid #dee2e6;
+        }
+        .logo {
+            font-size: 1.5rem;
+            font-weight: bold;
+            color: #333;
+        }
+        nav a {
+            color: #333;
+            text-decoration: none;
+            margin-left: 1rem;
+        }
+        nav a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="logo">Todoアプリ</div>
+        <nav>
+            <a href="index.php">ホーム</a>
+            <a href="../category/index.php">カテゴリ一覧</a>
+            <a href="../user/logout.php">ログアウト</a>
+        </nav>
+    </header>
+    <main>
+        <?php echo 'Welcome TECH QUEST!'; ?>
+    </main>
+</body>
+</html>

--- a/src/public/user/logout.php
+++ b/src/public/user/logout.php
@@ -1,0 +1,26 @@
+<?php
+session_start();
+
+// セッション変数を全て解除
+$_SESSION = [];
+
+// セッションクッキーを削除
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(
+        session_name(),
+        '',
+        time() - 42000,
+        $params['path'],
+        $params['domain'],
+        $params['secure'],
+        $params['httponly']
+    );
+}
+
+// セッションを破棄
+session_destroy();
+
+// signin.phpにリダイレクト
+header('Location: ../signin.php');
+exit();

--- a/src/public/user/signup.php
+++ b/src/public/user/signup.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>会員登録 - Todoアプリ</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 flex items-center justify-center min-h-screen">
+    <div class="bg-white p-8 rounded-lg shadow-md w-96">
+        <h1 class="text-2xl font-bold mb-6 text-center">会員登録</h1>
+        <form action="register.php" method="post">
+            <div class="mb-4">
+                <input type="text" id="username" name="username" placeholder="User name" required
+                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+            </div>
+            <div class="mb-4">
+                <input type="email" id="email" name="email" placeholder="Email" required
+                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+            </div>
+            <div class="mb-4">
+                <input type="password" id="password" name="password" placeholder="Password" required
+                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+            </div>
+            <div class="mb-6">
+                <input type="password" id="confirm_password" name="confirm_password" placeholder="Password確認" required
+                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+            </div>
+            <button type="submit"
+                class="w-full bg-blue-500 text-white py-2 rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+                アカウント作成
+            </button>
+        </form>
+        <div class="mt-4 text-center">
+            <a href="login.php" class="text-blue-500 hover:underline">ログイン画面へ</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/public/user/signup.php
+++ b/src/public/user/signup.php
@@ -1,3 +1,49 @@
+<?php
+session_start();
+// データベース接続設定
+try {
+    $dbUserName = 'root';
+    $dbPassword = 'password';
+    $pdo = new PDO(
+        'mysql:host=mysql; dbname=todo; charset=utf8mb4',
+        $dbUserName,
+        $dbPassword,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+} catch (PDOException $e) {
+    $error_message = 'データベース接続エラー: ' . $e->getMessage();
+    error_log($error_message);
+}
+
+$error_message = '';
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    if (empty($_POST['email']) || empty($_POST['password'])) {
+        $error_message = 'EmailかPasswordの入力がありません';
+    } elseif ($_POST['password'] !== $_POST['confirm_password']) {
+        $error_message = 'パスワードが一致しません';
+    } else {
+        // メールアドレスの重複チェック
+        $email = $_POST['email'];
+        $stmt = $pdo->prepare('SELECT * FROM users WHERE email = ?');
+        $stmt->execute([$email]);
+        if ($stmt->rowCount() > 0) {
+            $error_message = 'すでに保存されているメールアドレスです';
+        } else {
+            // ユーザー登録処理
+            $name = $_POST['username'];
+            $password = password_hash($_POST['password'], PASSWORD_DEFAULT);
+            $stmt = $pdo->prepare(
+                'INSERT INTO users (name, email, password) VALUES (?, ?, ?)'
+            );
+            $stmt->execute([$name, $email, $password]);
+
+            // signin.php にリダイレクト
+            header('Location: signin.php');
+            exit();
+        }
+    }
+}
+?>
 <!DOCTYPE html>
 <html lang="ja">
 <head>
@@ -9,21 +55,28 @@
 <body class="bg-gray-100 flex items-center justify-center min-h-screen">
     <div class="bg-white p-8 rounded-lg shadow-md w-96">
         <h1 class="text-2xl font-bold mb-6 text-center">会員登録</h1>
-        <form action="register.php" method="post">
+        <?php if ($error_message): ?>
+            <p class="text-red-500 text-center mb-4"><?php echo htmlspecialchars(
+                $error_message
+            ); ?></p>
+        <?php endif; ?>
+        <form action="<?php echo htmlspecialchars(
+            $_SERVER['PHP_SELF']
+        ); ?>" method="post">
             <div class="mb-4">
-                <input type="text" id="username" name="username" placeholder="User name" required
+                <input type="text" id="username" name="username" placeholder="User name" 
                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
             </div>
             <div class="mb-4">
-                <input type="email" id="email" name="email" placeholder="Email" required
+                <input type="email" id="email" name="email" placeholder="Email" 
                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
             </div>
             <div class="mb-4">
-                <input type="password" id="password" name="password" placeholder="Password" required
+                <input type="password" id="password" name="password" placeholder="Password" 
                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
             </div>
             <div class="mb-6">
-                <input type="password" id="confirm_password" name="confirm_password" placeholder="Password確認" required
+                <input type="password" id="confirm_password" name="confirm_password" placeholder="Password確認" 
                     class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
             </div>
             <button type="submit"


### PR DESCRIPTION
### アカウント作成フォームの表示
- ユーザー登録フォームの表示をする。
### ユーザー登録フォーム
- [アカウント作成ボタン]の押下時、[user/signup_complete.php]に遷移。

1. EmailかPasswordに入力がない場合、[EmailかPasswordの入力がありません]という文言をuser/signup.phpで表示。

2. パスワードが一致しない場合、[パスワードが一致しません]という文言をuser/signup.phpで表示。

3. 同一のemailがすでに保存されている場合、[すでに保存されているメールアドレスです]という文言をuser/signup.phpで表示。

_1~3のバリデーションに問題なければ、ユーザー登録処理を実行する。
処理後、user/signin.phpに遷移。_

https://github.com/user-attachments/assets/1fdd3342-03f1-4456-9f37-bc335a9a85e1


https://github.com/user-attachments/assets/5e10b732-2baf-440f-9179-7f53d7813b0b


https://github.com/user-attachments/assets/7c0fd44a-4277-4660-9a34-f5c34e07cff3

### ログインページへ遷移
- 「ログイン画面へ」の押下時、user/signin.phpに遷移。


https://github.com/user-attachments/assets/4e51a24a-9a21-47bd-9482-1b5f4005a2ad




